### PR TITLE
Datetime series slicing - No error with DateTimeSeries.loc() 

### DIFF
--- a/doc/source/getting_started/intro_tutorials/09_timeseries.rst
+++ b/doc/source/getting_started/intro_tutorials/09_timeseries.rst
@@ -263,7 +263,7 @@ Create a plot of the :math:`NO_2` values in the different stations from the 20th
     :okwarning:
 
     @savefig 09_time_section.png
-    no_2["2019-05-20":"2019-05-21"].plot();
+    no_2.loc["2019-05-20":"2019-05-21"].plot();
 
 By providing a **string that parses to a datetime**, a specific subset of the data can be selected on a ``DatetimeIndex``.
 


### PR DESCRIPTION
Date time series on slicing might produce errors for different reasons...which can be avoided with loc() on the DateTime.
Error would be like : *** Slicing with this method is *always* positional.***

After correcting the Issue
https://docs.google.com/document/d/1L5Ei0q5BfHCTnfzG43exvTug_N1OE7UEmxbgB0KjIh4/edit?usp=sharing

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] Ensure all linting tests pass, see [here](https://pandas.pydata.org/pandas-docs/dev/development/contributing.html#code-standards) for how to run them
- [ ] whatsnew entry
